### PR TITLE
Bump min SDK and update changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 dart:
   - dev
   - stable
-  - 1.21.1
+  - 1.23.0
 
 dart_task:
   - test: --platform vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.2
+
+* Require Dart SDK 1.23 or greater.
+
+* A number of strong-mode fixes.
+
 ## 3.1.1
 
 * Fix a logic bug in the `chunkedCoding` codec. It had been producing invalid

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/dart-lang/http_parser
 description: >
   A platform-independent package for parsing and serializing HTTP formats.
 environment:
-  sdk: ">=1.21.0 <2.0.0-dev.infinity"
+  sdk: ">=1.23.0 <2.0.0-dev.infinity"
 dependencies:
   charcode: "^1.1.0"
   collection: ">=0.9.1 <2.0.0"


### PR DESCRIPTION
We cannot reliably test on Travis pre 1.23.0