### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.3.0
   - dev
 
 dart_task:

--- a/lib/src/authentication_challenge.dart
+++ b/lib/src/authentication_challenge.dart
@@ -34,7 +34,7 @@ class AuthenticationChallenge {
   ///
   /// Throws a [FormatException] if the header is invalid.
   static List<AuthenticationChallenge> parseHeader(String header) {
-    return wrapFormatException("authentication header", header, () {
+    return wrapFormatException('authentication header', header, () {
       var scanner = StringScanner(header);
       scanner.scan(whitespace);
       var challenges = parseList(scanner, () {
@@ -45,20 +45,20 @@ class AuthenticationChallenge {
         var params = <String, String>{};
 
         // Consume initial empty values.
-        while (scanner.scan(",")) {
+        while (scanner.scan(',')) {
           scanner.scan(whitespace);
         }
 
         _scanAuthParam(scanner, params);
 
         var beforeComma = scanner.position;
-        while (scanner.scan(",")) {
+        while (scanner.scan(',')) {
           scanner.scan(whitespace);
 
           // Empty elements are allowed, but excluded from the results.
-          if (scanner.matches(",") || scanner.isDone) continue;
+          if (scanner.matches(',') || scanner.isDone) continue;
 
-          scanner.expect(token, name: "a token");
+          scanner.expect(token, name: 'a token');
           var name = scanner.lastMatch[0];
           scanner.scan(whitespace);
 
@@ -75,7 +75,7 @@ class AuthenticationChallenge {
             params[name] = scanner.lastMatch[0];
           } else {
             params[name] =
-                expectQuotedString(scanner, name: "a token or a quoted string");
+                expectQuotedString(scanner, name: 'a token or a quoted string');
           }
 
           scanner.scan(whitespace);
@@ -94,7 +94,7 @@ class AuthenticationChallenge {
   ///
   /// Throws a [FormatException] if the challenge is invalid.
   factory AuthenticationChallenge.parse(String challenge) {
-    return wrapFormatException("authentication challenge", challenge, () {
+    return wrapFormatException('authentication challenge', challenge, () {
       var scanner = StringScanner(challenge);
       scanner.scan(whitespace);
       var scheme = _scanScheme(scanner);
@@ -112,15 +112,15 @@ class AuthenticationChallenge {
   /// If [whitespaceName] is passed, it's used as the name for exceptions thrown
   /// due to invalid trailing whitespace.
   static String _scanScheme(StringScanner scanner, {String whitespaceName}) {
-    scanner.expect(token, name: "a token");
+    scanner.expect(token, name: 'a token');
     var scheme = scanner.lastMatch[0].toLowerCase();
 
     scanner.scan(whitespace);
 
     // The spec specifically requires a space between the scheme and its
     // params.
-    if (scanner.lastMatch == null || !scanner.lastMatch[0].contains(" ")) {
-      scanner.expect(" ", name: whitespaceName);
+    if (scanner.lastMatch == null || !scanner.lastMatch[0].contains(' ')) {
+      scanner.expect(' ', name: whitespaceName);
     }
 
     return scheme;
@@ -128,7 +128,7 @@ class AuthenticationChallenge {
 
   /// Scans a single authentication parameter and stores its result in [params].
   static void _scanAuthParam(StringScanner scanner, Map params) {
-    scanner.expect(token, name: "a token");
+    scanner.expect(token, name: 'a token');
     var name = scanner.lastMatch[0];
     scanner.scan(whitespace);
     scanner.expect('=');
@@ -138,7 +138,7 @@ class AuthenticationChallenge {
       params[name] = scanner.lastMatch[0];
     } else {
       params[name] =
-          expectQuotedString(scanner, name: "a token or a quoted string");
+          expectQuotedString(scanner, name: 'a token or a quoted string');
     }
 
     scanner.scan(whitespace);

--- a/lib/src/chunked_coding/decoder.dart
+++ b/lib/src/chunked_coding/decoder.dart
@@ -22,7 +22,7 @@ class ChunkedCodingDecoder extends Converter<List<int>, List<int>> {
     var output = sink._decode(input, 0, input.length);
     if (sink._state == _State.end) return output;
 
-    throw FormatException("Input ended unexpectedly.", input, input.length);
+    throw FormatException('Input ended unexpectedly.', input, input.length);
   }
 
   @override
@@ -62,7 +62,7 @@ class _Sink extends ByteConversionSinkBase {
   /// one is thrown.
   void _close([List<int> chunk, int index]) {
     if (_state != _State.end) {
-      throw FormatException("Input ended unexpectedly.", chunk, index);
+      throw FormatException('Input ended unexpectedly.', chunk, index);
     }
 
     _sink.close();
@@ -74,7 +74,7 @@ class _Sink extends ByteConversionSinkBase {
     /// describe the character in the exception text.
     void assertCurrentChar(int char, String name) {
       if (bytes[start] != char) {
-        throw FormatException("Expected $name.", bytes, start);
+        throw FormatException('Expected $name.', bytes, start);
       }
     }
 
@@ -99,7 +99,7 @@ class _Sink extends ByteConversionSinkBase {
           break;
 
         case _State.sizeBeforeLF:
-          assertCurrentChar($lf, "LF");
+          assertCurrentChar($lf, 'LF');
           _state = _size == 0 ? _State.endBeforeCR : _State.body;
           start++;
           break;
@@ -113,31 +113,31 @@ class _Sink extends ByteConversionSinkBase {
           break;
 
         case _State.bodyBeforeCR:
-          assertCurrentChar($cr, "CR");
+          assertCurrentChar($cr, 'CR');
           _state = _State.bodyBeforeLF;
           start++;
           break;
 
         case _State.bodyBeforeLF:
-          assertCurrentChar($lf, "LF");
+          assertCurrentChar($lf, 'LF');
           _state = _State.boundary;
           start++;
           break;
 
         case _State.endBeforeCR:
-          assertCurrentChar($cr, "CR");
+          assertCurrentChar($cr, 'CR');
           _state = _State.endBeforeLF;
           start++;
           break;
 
         case _State.endBeforeLF:
-          assertCurrentChar($lf, "LF");
+          assertCurrentChar($lf, 'LF');
           _state = _State.end;
           start++;
           break;
 
         case _State.end:
-          throw FormatException("Expected no more data.", bytes, start);
+          throw FormatException('Expected no more data.', bytes, start);
       }
     }
     return buffer.buffer.asUint8List(0, buffer.length);
@@ -170,7 +170,7 @@ class _Sink extends ByteConversionSinkBase {
     }
 
     throw FormatException(
-        "Invalid hexadecimal byte 0x${byte.toRadixString(16).toUpperCase()}.",
+        'Invalid hexadecimal byte 0x${byte.toRadixString(16).toUpperCase()}.',
         bytes,
         index);
   }
@@ -183,53 +183,53 @@ class _State {
   /// next chunk.
   ///
   /// Transitions to [size].
-  static const boundary = _State._("boundary");
+  static const boundary = _State._('boundary');
 
   /// The parser has parsed at least one digit of the chunk size header, but has
   /// not yet parsed the `CR LF` sequence that indicates the end of that header.
   ///
   /// Transitions to [sizeBeforeLF].
-  static const size = _State._("size");
+  static const size = _State._('size');
 
   /// The parser has parsed the chunk size header and the CR character after it,
   /// but not the LF.
   ///
   /// Transitions to [body] or [bodyBeforeCR].
-  static const sizeBeforeLF = _State._("size before LF");
+  static const sizeBeforeLF = _State._('size before LF');
 
   /// The parser has parsed a chunk header and possibly some of the body, but
   /// still needs to consume more bytes.
   ///
   /// Transitions to [bodyBeforeCR].
-  static const body = _State._("body");
+  static const body = _State._('body');
 
   // The parser has parsed all the bytes in a chunk body but not the CR LF
   // sequence that follows it.
   //
   // Transitions to [bodyBeforeLF].
-  static const bodyBeforeCR = _State._("body before CR");
+  static const bodyBeforeCR = _State._('body before CR');
 
   // The parser has parsed all the bytes in a chunk body and the CR that follows
   // it, but not the LF after that.
   //
   // Transitions to [bounday].
-  static const bodyBeforeLF = _State._("body before LF");
+  static const bodyBeforeLF = _State._('body before LF');
 
   /// The parser has parsed the final empty chunk but not the CR LF sequence
   /// that follows it.
   ///
   /// Transitions to [endBeforeLF].
-  static const endBeforeCR = _State._("end before CR");
+  static const endBeforeCR = _State._('end before CR');
 
   /// The parser has parsed the final empty chunk and the CR that follows it,
   /// but not the LF after that.
   ///
   /// Transitions to [end].
-  static const endBeforeLF = _State._("end before LF");
+  static const endBeforeLF = _State._('end before LF');
 
   /// The parser has parsed the final empty chunk as well as the CR LF that
   /// follows, and expects no more data.
-  static const end = _State._("end");
+  static const end = _State._('end');
 
   final String _name;
 

--- a/lib/src/http_date.dart
+++ b/lib/src/http_date.dart
@@ -6,27 +6,27 @@ import 'package:string_scanner/string_scanner.dart';
 
 import 'utils.dart';
 
-const _weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const _weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const _months = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec"
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
 ];
 
-final _shortWeekdayRegExp = RegExp(r"Mon|Tue|Wed|Thu|Fri|Sat|Sun");
+final _shortWeekdayRegExp = RegExp(r'Mon|Tue|Wed|Thu|Fri|Sat|Sun');
 final _longWeekdayRegExp =
-    RegExp(r"Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday");
-final _monthRegExp = RegExp(r"Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec");
-final _digitRegExp = RegExp(r"\d+");
+    RegExp(r'Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday');
+final _monthRegExp = RegExp(r'Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec');
+final _digitRegExp = RegExp(r'\d+');
 
 /// Return a HTTP-formatted string representation of [date].
 ///
@@ -36,20 +36,20 @@ String formatHttpDate(DateTime date) {
   date = date.toUtc();
   var buffer = StringBuffer()
     ..write(_weekdays[date.weekday - 1])
-    ..write(", ")
-    ..write(date.day <= 9 ? "0" : "")
+    ..write(', ')
+    ..write(date.day <= 9 ? '0' : '')
     ..write(date.day.toString())
-    ..write(" ")
+    ..write(' ')
     ..write(_months[date.month - 1])
-    ..write(" ")
+    ..write(' ')
     ..write(date.year.toString())
-    ..write(date.hour <= 9 ? " 0" : " ")
+    ..write(date.hour <= 9 ? ' 0' : ' ')
     ..write(date.hour.toString())
-    ..write(date.minute <= 9 ? ":0" : ":")
+    ..write(date.minute <= 9 ? ':0' : ':')
     ..write(date.minute.toString())
-    ..write(date.second <= 9 ? ":0" : ":")
+    ..write(date.second <= 9 ? ':0' : ':')
     ..write(date.second.toString())
-    ..write(" GMT");
+    ..write(' GMT');
   return buffer.toString();
 }
 
@@ -59,20 +59,20 @@ String formatHttpDate(DateTime date) {
 /// 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3). It will
 /// throw a [FormatException] if [date] is invalid.
 DateTime parseHttpDate(String date) {
-  return wrapFormatException("HTTP date", date, () {
+  return wrapFormatException('HTTP date', date, () {
     var scanner = StringScanner(date);
 
     if (scanner.scan(_longWeekdayRegExp)) {
       // RFC 850 starts with a long weekday.
-      scanner.expect(", ");
+      scanner.expect(', ');
       var day = _parseInt(scanner, 2);
-      scanner.expect("-");
+      scanner.expect('-');
       var month = _parseMonth(scanner);
-      scanner.expect("-");
+      scanner.expect('-');
       var year = 1900 + _parseInt(scanner, 2);
-      scanner.expect(" ");
+      scanner.expect(' ');
       var time = _parseTime(scanner);
-      scanner.expect(" GMT");
+      scanner.expect(' GMT');
       scanner.expectDone();
 
       return _makeDateTime(year, month, day, time);
@@ -80,29 +80,29 @@ DateTime parseHttpDate(String date) {
 
     // RFC 1123 and asctime both start with a short weekday.
     scanner.expect(_shortWeekdayRegExp);
-    if (scanner.scan(", ")) {
+    if (scanner.scan(', ')) {
       // RFC 1123 follows the weekday with a comma.
       var day = _parseInt(scanner, 2);
-      scanner.expect(" ");
+      scanner.expect(' ');
       var month = _parseMonth(scanner);
-      scanner.expect(" ");
+      scanner.expect(' ');
       var year = _parseInt(scanner, 4);
-      scanner.expect(" ");
+      scanner.expect(' ');
       var time = _parseTime(scanner);
-      scanner.expect(" GMT");
+      scanner.expect(' GMT');
       scanner.expectDone();
 
       return _makeDateTime(year, month, day, time);
     }
 
     // asctime follows the weekday with a space.
-    scanner.expect(" ");
+    scanner.expect(' ');
     var month = _parseMonth(scanner);
-    scanner.expect(" ");
-    var day = scanner.scan(" ") ? _parseInt(scanner, 1) : _parseInt(scanner, 2);
-    scanner.expect(" ");
+    scanner.expect(' ');
+    var day = scanner.scan(' ') ? _parseInt(scanner, 1) : _parseInt(scanner, 2);
+    scanner.expect(' ');
     var time = _parseTime(scanner);
-    scanner.expect(" ");
+    scanner.expect(' ');
     var year = _parseInt(scanner, 4);
     scanner.expectDone();
 
@@ -121,7 +121,7 @@ int _parseMonth(StringScanner scanner) {
 int _parseInt(StringScanner scanner, int digits) {
   scanner.expect(_digitRegExp);
   if (scanner.lastMatch[0].length != digits) {
-    scanner.error("expected a $digits-digit number.");
+    scanner.error('expected a $digits-digit number.');
   }
 
   return int.parse(scanner.lastMatch[0]);
@@ -130,15 +130,15 @@ int _parseInt(StringScanner scanner, int digits) {
 /// Parses an timestamp of the form "HH:MM:SS" on a 24-hour clock.
 DateTime _parseTime(StringScanner scanner) {
   var hours = _parseInt(scanner, 2);
-  if (hours >= 24) scanner.error("hours may not be greater than 24.");
+  if (hours >= 24) scanner.error('hours may not be greater than 24.');
   scanner.expect(':');
 
   var minutes = _parseInt(scanner, 2);
-  if (minutes >= 60) scanner.error("minutes may not be greater than 60.");
+  if (minutes >= 60) scanner.error('minutes may not be greater than 60.');
   scanner.expect(':');
 
   var seconds = _parseInt(scanner, 2);
-  if (seconds >= 60) scanner.error("seconds may not be greater than 60.");
+  if (seconds >= 60) scanner.error('seconds may not be greater than 60.');
 
   return DateTime(1, 1, 1, hours, minutes, seconds);
 }

--- a/lib/src/media_type.dart
+++ b/lib/src/media_type.dart
@@ -35,7 +35,7 @@ class MediaType {
   final Map<String, String> parameters;
 
   /// The media type's MIME type.
-  String get mimeType => "$type/$subtype";
+  String get mimeType => '$type/$subtype';
 
   /// Parses a media type.
   ///
@@ -43,7 +43,7 @@ class MediaType {
   factory MediaType.parse(String mediaType) {
     // This parsing is based on sections 3.6 and 3.7 of the HTTP spec:
     // http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html.
-    return wrapFormatException("media type", mediaType, () {
+    return wrapFormatException('media type', mediaType, () {
       var scanner = StringScanner(mediaType);
       scanner.scan(whitespace);
       scanner.expect(token);
@@ -99,10 +99,10 @@ class MediaType {
       bool clearParameters = false}) {
     if (mimeType != null) {
       if (type != null) {
-        throw ArgumentError("You may not pass both [type] and [mimeType].");
+        throw ArgumentError('You may not pass both [type] and [mimeType].');
       } else if (subtype != null) {
-        throw ArgumentError("You may not pass both [subtype] and "
-            "[mimeType].");
+        throw ArgumentError('You may not pass both [subtype] and '
+            '[mimeType].');
       }
 
       var segments = mimeType.split('/');
@@ -132,15 +132,15 @@ class MediaType {
   /// This will produce a valid HTTP media type.
   @override
   String toString() {
-    var buffer = StringBuffer()..write(type)..write("/")..write(subtype);
+    var buffer = StringBuffer()..write(type)..write('/')..write(subtype);
 
     parameters.forEach((attribute, value) {
-      buffer.write("; $attribute=");
+      buffer.write('; $attribute=');
       if (nonToken.hasMatch(value)) {
         buffer
           ..write('"')
           ..write(
-              value.replaceAllMapped(_escapedChar, (match) => "\\" + match[0]))
+              value.replaceAllMapped(_escapedChar, (match) => '\\' + match[0]))
           ..write('"');
       } else {
         buffer.write(value);

--- a/lib/src/scan.dart
+++ b/lib/src/scan.dart
@@ -22,7 +22,7 @@ import 'package:string_scanner/string_scanner.dart';
 final token = RegExp(r'[^()<>@,;:"\\/[\]?={} \t\x00-\x1F\x7F]+');
 
 /// Linear whitespace.
-final _lws = RegExp(r"(?:\r\n)?[ \t]+");
+final _lws = RegExp(r'(?:\r\n)?[ \t]+');
 
 /// A quoted string.
 final _quotedString = RegExp(r'"(?:[^"\x00-\x1F\x7F]|\\.)*"');
@@ -34,7 +34,7 @@ final _quotedPair = RegExp(r'\\(.)');
 final nonToken = RegExp(r'[()<>@,;:"\\/\[\]?={} \t\x00-\x1F\x7F]');
 
 /// A regular expression matching any number of [_lws] productions in a row.
-final whitespace = RegExp("(?:${_lws.pattern})*");
+final whitespace = RegExp('(?:${_lws.pattern})*');
 
 /// Parses a list of elements, as in `1#element` in the HTTP spec.
 ///
@@ -48,18 +48,18 @@ List<T> parseList<T>(StringScanner scanner, T Function() parseElement) {
   var result = <T>[];
 
   // Consume initial empty values.
-  while (scanner.scan(",")) {
+  while (scanner.scan(',')) {
     scanner.scan(whitespace);
   }
 
   result.add(parseElement());
   scanner.scan(whitespace);
 
-  while (scanner.scan(",")) {
+  while (scanner.scan(',')) {
     scanner.scan(whitespace);
 
     // Empty elements are allowed, but excluded from the results.
-    if (scanner.matches(",") || scanner.isDone) continue;
+    if (scanner.matches(',') || scanner.isDone) continue;
 
     result.add(parseElement());
     scanner.scan(whitespace);
@@ -73,7 +73,7 @@ List<T> parseList<T>(StringScanner scanner, T Function() parseElement) {
 /// If [name] is passed, it's used to describe the expected value if it's not
 /// found.
 String expectQuotedString(StringScanner scanner, {String name}) {
-  name ??= "quoted string";
+  name ??= 'quoted string';
   scanner.expect(_quotedString, name: name);
   var string = scanner.lastMatch[0];
   return string

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_parser
-version: 3.1.3
+version: 3.1.4-dev
 
 description: >
   A platform-independent package for parsing and serializing HTTP formats.
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http_parser
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   charcode: ^1.1.0

--- a/test/authentication_challenge_test.dart
+++ b/test/authentication_challenge_test.dart
@@ -6,13 +6,13 @@ import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("parse", () {
+  group('parse', () {
     _singleChallengeTests(
         (challenge) => AuthenticationChallenge.parse(challenge));
   });
 
-  group("parseHeader", () {
-    group("with a single challenge", () {
+  group('parseHeader', () {
+    group('with a single challenge', () {
       _singleChallengeTests((challenge) {
         var challenges = AuthenticationChallenge.parseHeader(challenge);
         expect(challenges, hasLength(1));
@@ -20,28 +20,28 @@ void main() {
       });
     });
 
-    test("parses multiple challenges", () {
+    test('parses multiple challenges', () {
       var challenges = AuthenticationChallenge.parseHeader(
-          "scheme1 realm=fblthp, scheme2 realm=asdfg");
+          'scheme1 realm=fblthp, scheme2 realm=asdfg');
       expect(challenges, hasLength(2));
-      expect(challenges.first.scheme, equals("scheme1"));
-      expect(challenges.first.parameters, equals({"realm": "fblthp"}));
-      expect(challenges.last.scheme, equals("scheme2"));
-      expect(challenges.last.parameters, equals({"realm": "asdfg"}));
+      expect(challenges.first.scheme, equals('scheme1'));
+      expect(challenges.first.parameters, equals({'realm': 'fblthp'}));
+      expect(challenges.last.scheme, equals('scheme2'));
+      expect(challenges.last.parameters, equals({'realm': 'asdfg'}));
     });
 
-    test("parses multiple challenges with multiple parameters", () {
+    test('parses multiple challenges with multiple parameters', () {
       var challenges = AuthenticationChallenge.parseHeader(
-          "scheme1 realm=fblthp, foo=bar, scheme2 realm=asdfg, baz=bang");
+          'scheme1 realm=fblthp, foo=bar, scheme2 realm=asdfg, baz=bang');
       expect(challenges, hasLength(2));
 
-      expect(challenges.first.scheme, equals("scheme1"));
+      expect(challenges.first.scheme, equals('scheme1'));
       expect(challenges.first.parameters,
-          equals({"realm": "fblthp", "foo": "bar"}));
+          equals({'realm': 'fblthp', 'foo': 'bar'}));
 
-      expect(challenges.last.scheme, equals("scheme2"));
+      expect(challenges.last.scheme, equals('scheme2'));
       expect(challenges.last.parameters,
-          equals({"realm": "asdfg", "baz": "bang"}));
+          equals({'realm': 'asdfg', 'baz': 'bang'}));
     });
   });
 }
@@ -53,90 +53,90 @@ void main() {
 /// separate code paths.
 void _singleChallengeTests(
     AuthenticationChallenge Function(String challenge) parseChallenge) {
-  test("parses a simple challenge", () {
-    var challenge = parseChallenge("scheme realm=fblthp");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp"}));
+  test('parses a simple challenge', () {
+    var challenge = parseChallenge('scheme realm=fblthp');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp'}));
   });
 
-  test("parses multiple parameters", () {
-    var challenge = parseChallenge("scheme realm=fblthp, foo=bar, baz=qux");
-    expect(challenge.scheme, equals("scheme"));
+  test('parses multiple parameters', () {
+    var challenge = parseChallenge('scheme realm=fblthp, foo=bar, baz=qux');
+    expect(challenge.scheme, equals('scheme'));
     expect(challenge.parameters,
-        equals({"realm": "fblthp", "foo": "bar", "baz": "qux"}));
+        equals({'realm': 'fblthp', 'foo': 'bar', 'baz': 'qux'}));
   });
 
-  test("parses quoted string parameters", () {
+  test('parses quoted string parameters', () {
     var challenge = parseChallenge('scheme realm="fblthp, foo=bar", baz="qux"');
-    expect(challenge.scheme, equals("scheme"));
+    expect(challenge.scheme, equals('scheme'));
     expect(challenge.parameters,
-        equals({"realm": "fblthp, foo=bar", "baz": "qux"}));
+        equals({'realm': 'fblthp, foo=bar', 'baz': 'qux'}));
   });
 
-  test("normalizes the case of the scheme", () {
-    var challenge = parseChallenge("ScHeMe realm=fblthp");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp"}));
+  test('normalizes the case of the scheme', () {
+    var challenge = parseChallenge('ScHeMe realm=fblthp');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp'}));
   });
 
-  test("normalizes the case of the parameter name", () {
-    var challenge = parseChallenge("scheme ReAlM=fblthp");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, containsPair("realm", "fblthp"));
+  test('normalizes the case of the parameter name', () {
+    var challenge = parseChallenge('scheme ReAlM=fblthp');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, containsPair('realm', 'fblthp'));
   });
 
   test("doesn't normalize the case of the parameter value", () {
-    var challenge = parseChallenge("scheme realm=FbLtHp");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, containsPair("realm", "FbLtHp"));
-    expect(challenge.parameters, isNot(containsPair("realm", "fblthp")));
+    var challenge = parseChallenge('scheme realm=FbLtHp');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, containsPair('realm', 'FbLtHp'));
+    expect(challenge.parameters, isNot(containsPair('realm', 'fblthp')));
   });
 
-  test("allows extra whitespace", () {
+  test('allows extra whitespace', () {
     var challenge = parseChallenge(
-        "  scheme\t \trealm\t = \tfblthp\t, \tfoo\t\r\n =\tbar\t");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp", "foo": "bar"}));
+        '  scheme\t \trealm\t = \tfblthp\t, \tfoo\t\r\n =\tbar\t');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp', 'foo': 'bar'}));
   });
 
-  test("allows an empty parameter", () {
-    var challenge = parseChallenge("scheme realm=fblthp, , foo=bar");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp", "foo": "bar"}));
+  test('allows an empty parameter', () {
+    var challenge = parseChallenge('scheme realm=fblthp, , foo=bar');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp', 'foo': 'bar'}));
   });
 
-  test("allows a leading comma", () {
-    var challenge = parseChallenge("scheme , realm=fblthp, foo=bar,");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp", "foo": "bar"}));
+  test('allows a leading comma', () {
+    var challenge = parseChallenge('scheme , realm=fblthp, foo=bar,');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp', 'foo': 'bar'}));
   });
 
-  test("allows a trailing comma", () {
-    var challenge = parseChallenge("scheme realm=fblthp, foo=bar, ,");
-    expect(challenge.scheme, equals("scheme"));
-    expect(challenge.parameters, equals({"realm": "fblthp", "foo": "bar"}));
+  test('allows a trailing comma', () {
+    var challenge = parseChallenge('scheme realm=fblthp, foo=bar, ,');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters, equals({'realm': 'fblthp', 'foo': 'bar'}));
   });
 
-  test("disallows only a scheme", () {
-    expect(() => parseChallenge("scheme"), throwsFormatException);
+  test('disallows only a scheme', () {
+    expect(() => parseChallenge('scheme'), throwsFormatException);
   });
 
-  test("disallows a valueless parameter", () {
-    expect(() => parseChallenge("scheme realm"), throwsFormatException);
-    expect(() => parseChallenge("scheme realm="), throwsFormatException);
+  test('disallows a valueless parameter', () {
+    expect(() => parseChallenge('scheme realm'), throwsFormatException);
+    expect(() => parseChallenge('scheme realm='), throwsFormatException);
     expect(
-        () => parseChallenge("scheme realm, foo=bar"), throwsFormatException);
+        () => parseChallenge('scheme realm, foo=bar'), throwsFormatException);
   });
 
-  test("requires a space after the scheme", () {
-    expect(() => parseChallenge("scheme\trealm"), throwsFormatException);
-    expect(() => parseChallenge("scheme\r\n\trealm="), throwsFormatException);
+  test('requires a space after the scheme', () {
+    expect(() => parseChallenge('scheme\trealm'), throwsFormatException);
+    expect(() => parseChallenge('scheme\r\n\trealm='), throwsFormatException);
   });
 
-  test("disallows junk after the parameters", () {
+  test('disallows junk after the parameters', () {
     expect(
-        () => parseChallenge("scheme realm=fblthp foo"), throwsFormatException);
-    expect(() => parseChallenge("scheme realm=fblthp, foo=bar baz"),
+        () => parseChallenge('scheme realm=fblthp foo'), throwsFormatException);
+    expect(() => parseChallenge('scheme realm=fblthp, foo=bar baz'),
         throwsFormatException);
   });
 }

--- a/test/case_insensitive_map_test.dart
+++ b/test/case_insensitive_map_test.dart
@@ -6,24 +6,24 @@ import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("provides case-insensitive access to the map", () {
+  test('provides case-insensitive access to the map', () {
     var map = CaseInsensitiveMap();
-    map["fOo"] = "bAr";
-    expect(map, containsPair("FoO", "bAr"));
+    map['fOo'] = 'bAr';
+    expect(map, containsPair('FoO', 'bAr'));
 
-    map["foo"] = "baz";
-    expect(map, containsPair("FOO", "baz"));
+    map['foo'] = 'baz';
+    expect(map, containsPair('FOO', 'baz'));
   });
 
-  test("stores the original key cases", () {
+  test('stores the original key cases', () {
     var map = CaseInsensitiveMap();
-    map["fOo"] = "bAr";
-    expect(map, equals({"fOo": "bAr"}));
+    map['fOo'] = 'bAr';
+    expect(map, equals({'fOo': 'bAr'}));
   });
 
-  test(".from() converts an existing map", () {
-    var map = CaseInsensitiveMap.from({"fOo": "bAr"});
-    expect(map, containsPair("FoO", "bAr"));
-    expect(map, equals({"fOo": "bAr"}));
+  test('.from() converts an existing map', () {
+    var map = CaseInsensitiveMap.from({'fOo': 'bAr'});
+    expect(map, containsPair('FoO', 'bAr'));
+    expect(map, equals({'fOo': 'bAr'}));
   });
 }

--- a/test/chunked_coding_test.dart
+++ b/test/chunked_coding_test.dart
@@ -11,26 +11,25 @@ import 'package:charcode/charcode.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("encoder", () {
-    test("adds a header to the chunk of bytes", () {
+  group('encoder', () {
+    test('adds a header to the chunk of bytes', () {
       expect(chunkedCoding.encode([1, 2, 3]),
           equals([$3, $cr, $lf, 1, 2, 3, $cr, $lf, $0, $cr, $lf, $cr, $lf]));
     });
 
-    test("uses hex for chunk size", () {
+    test('uses hex for chunk size', () {
       var data = Iterable<int>.generate(0xA7).toList();
       expect(
           chunkedCoding.encode(data),
-          equals([$a, $7, $cr, $lf]
-            ..addAll(data)
-            ..addAll([$cr, $lf, $0, $cr, $lf, $cr, $lf])));
+          equals(
+              [$a, $7, $cr, $lf, ...data, $cr, $lf, $0, $cr, $lf, $cr, $lf]));
     });
 
-    test("just generates a footer for an empty input", () {
+    test('just generates a footer for an empty input', () {
       expect(chunkedCoding.encode([]), equals([$0, $cr, $lf, $cr, $lf]));
     });
 
-    group("with chunked conversion", () {
+    group('with chunked conversion', () {
       List<List<int>> results;
       ByteConversionSink sink;
       setUp(() {
@@ -40,7 +39,7 @@ void main() {
         sink = chunkedCoding.encoder.startChunkedConversion(controller.sink);
       });
 
-      test("adds headers to each chunk of bytes", () {
+      test('adds headers to each chunk of bytes', () {
         sink.add([1, 2, 3, 4]);
         expect(
             results,
@@ -66,7 +65,7 @@ void main() {
             ]));
       });
 
-      test("handles empty chunks", () {
+      test('handles empty chunks', () {
         sink.add([]);
         expect(results, equals([[]]));
 
@@ -98,8 +97,8 @@ void main() {
             ]));
       });
 
-      group("addSlice()", () {
-        test("adds bytes from the specified slice", () {
+      group('addSlice()', () {
+        test('adds bytes from the specified slice', () {
           sink.addSlice([1, 2, 3, 4, 5], 1, 4, false);
           expect(
               results,
@@ -113,7 +112,7 @@ void main() {
           expect(results, equals([[]]));
         });
 
-        test("adds a footer if isLast is true", () {
+        test('adds a footer if isLast is true', () {
           sink.addSlice([1, 2, 3, 4, 5], 1, 4, true);
           expect(
               results,
@@ -125,18 +124,18 @@ void main() {
           expect(() => sink.add([]), throwsStateError);
         });
 
-        group("disallows", () {
-          test("start < 0", () {
+        group('disallows', () {
+          test('start < 0', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], -1, 4, false),
                 throwsRangeError);
           });
 
-          test("start > end", () {
+          test('start > end', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], 3, 2, false),
                 throwsRangeError);
           });
 
-          test("end > length", () {
+          test('end > length', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], 1, 10, false),
                 throwsRangeError);
           });
@@ -145,8 +144,8 @@ void main() {
     });
   });
 
-  group("decoder", () {
-    test("parses chunked data", () {
+  group('decoder', () {
+    test('parses chunked data', () {
       expect(
           chunkedCoding.decode([
             $3,
@@ -175,47 +174,45 @@ void main() {
           equals([1, 2, 3, 4, 5, 6, 7]));
     });
 
-    test("parses hex size", () {
+    test('parses hex size', () {
       var data = Iterable<int>.generate(0xA7).toList();
       expect(
-          chunkedCoding.decode([$a, $7, $cr, $lf]
-            ..addAll(data)
-            ..addAll([$cr, $lf, $0, $cr, $lf, $cr, $lf])),
+          chunkedCoding.decode(
+              [$a, $7, $cr, $lf, ...data, $cr, $lf, $0, $cr, $lf, $cr, $lf]),
           equals(data));
     });
 
-    test("parses capital hex size", () {
+    test('parses capital hex size', () {
       var data = Iterable<int>.generate(0xA7).toList();
       expect(
-          chunkedCoding.decode([$A, $7, $cr, $lf]
-            ..addAll(data)
-            ..addAll([$cr, $lf, $0, $cr, $lf, $cr, $lf])),
+          chunkedCoding.decode(
+              [$A, $7, $cr, $lf, ...data, $cr, $lf, $0, $cr, $lf, $cr, $lf]),
           equals(data));
     });
 
-    test("parses an empty message", () {
+    test('parses an empty message', () {
       expect(chunkedCoding.decode([$0, $cr, $lf, $cr, $lf]), isEmpty);
     });
 
-    group("disallows a message", () {
-      test("that ends without any input", () {
+    group('disallows a message', () {
+      test('that ends without any input', () {
         expect(() => chunkedCoding.decode([]), throwsFormatException);
       });
 
-      test("that ends after the size", () {
+      test('that ends after the size', () {
         expect(() => chunkedCoding.decode([$a]), throwsFormatException);
       });
 
-      test("that ends after CR", () {
+      test('that ends after CR', () {
         expect(() => chunkedCoding.decode([$a, $cr]), throwsFormatException);
       });
 
-      test("that ends after LF", () {
+      test('that ends after LF', () {
         expect(
             () => chunkedCoding.decode([$a, $cr, $lf]), throwsFormatException);
       });
 
-      test("that ends after insufficient bytes", () {
+      test('that ends after insufficient bytes', () {
         expect(() => chunkedCoding.decode([$a, $cr, $lf, 1, 2, 3]),
             throwsFormatException);
       });
@@ -235,29 +232,29 @@ void main() {
             throwsFormatException);
       });
 
-      test("that ends after the empty chunk", () {
+      test('that ends after the empty chunk', () {
         expect(
             () => chunkedCoding.decode([$0, $cr, $lf]), throwsFormatException);
       });
 
-      test("that ends after the closing CR", () {
+      test('that ends after the closing CR', () {
         expect(() => chunkedCoding.decode([$0, $cr, $lf, $cr]),
             throwsFormatException);
       });
 
-      test("with a chunk without a size", () {
+      test('with a chunk without a size', () {
         expect(() => chunkedCoding.decode([$cr, $lf, $0, $cr, $lf, $cr, $lf]),
             throwsFormatException);
       });
 
-      test("with a chunk with a non-hex size", () {
+      test('with a chunk with a non-hex size', () {
         expect(
             () => chunkedCoding.decode([$q, $cr, $lf, $0, $cr, $lf, $cr, $lf]),
             throwsFormatException);
       });
     });
 
-    group("with chunked conversion", () {
+    group('with chunked conversion', () {
       List<List<int>> results;
       ByteConversionSink sink;
       setUp(() {
@@ -267,7 +264,7 @@ void main() {
         sink = chunkedCoding.decoder.startChunkedConversion(controller.sink);
       });
 
-      test("decodes each chunk of bytes", () {
+      test('decodes each chunk of bytes', () {
         sink.add([$4, $cr, $lf, 1, 2, 3, 4, $cr, $lf]);
         expect(
             results,
@@ -293,7 +290,7 @@ void main() {
             ]));
       });
 
-      test("handles empty chunks", () {
+      test('handles empty chunks', () {
         sink.add([]);
         expect(results, isEmpty);
 
@@ -320,22 +317,22 @@ void main() {
             ]));
       });
 
-      test("throws if the sink is closed before the message is done", () {
+      test('throws if the sink is closed before the message is done', () {
         sink.add([$3, $cr, $lf, 1, 2, 3]);
         expect(() => sink.close(), throwsFormatException);
       });
 
-      group("preserves state when a byte array ends", () {
-        test("within chunk size", () {
+      group('preserves state when a byte array ends', () {
+        test('within chunk size', () {
           sink.add([$a]);
           expect(results, isEmpty);
 
           var data = Iterable<int>.generate(0xA7).toList();
-          sink.add([$7, $cr, $lf]..addAll(data));
+          sink.add([$7, $cr, $lf, ...data]);
           expect(results, equals([data]));
         });
 
-        test("after chunk size", () {
+        test('after chunk size', () {
           sink.add([$3]);
           expect(results, isEmpty);
 
@@ -347,7 +344,7 @@ void main() {
               ]));
         });
 
-        test("after CR", () {
+        test('after CR', () {
           sink.add([$3, $cr]);
           expect(results, isEmpty);
 
@@ -359,7 +356,7 @@ void main() {
               ]));
         });
 
-        test("after LF", () {
+        test('after LF', () {
           sink.add([$3, $cr, $lf]);
           expect(results, isEmpty);
 
@@ -371,7 +368,7 @@ void main() {
               ]));
         });
 
-        test("after some bytes", () {
+        test('after some bytes', () {
           sink.add([$3, $cr, $lf, 1, 2]);
           expect(
               results,
@@ -388,7 +385,7 @@ void main() {
               ]));
         });
 
-        test("after all bytes", () {
+        test('after all bytes', () {
           sink.add([$3, $cr, $lf, 1, 2, 3]);
           expect(
               results,
@@ -405,7 +402,7 @@ void main() {
               ]));
         });
 
-        test("after a post-chunk CR", () {
+        test('after a post-chunk CR', () {
           sink.add([$3, $cr, $lf, 1, 2, 3, $cr]);
           expect(
               results,
@@ -422,7 +419,7 @@ void main() {
               ]));
         });
 
-        test("after a post-chunk LF", () {
+        test('after a post-chunk LF', () {
           sink.add([$3, $cr, $lf, 1, 2, 3, $cr, $lf]);
           expect(
               results,
@@ -439,7 +436,7 @@ void main() {
               ]));
         });
 
-        test("after empty chunk size", () {
+        test('after empty chunk size', () {
           sink.add([$0]);
           expect(results, isEmpty);
 
@@ -450,7 +447,7 @@ void main() {
           expect(results, isEmpty);
         });
 
-        test("after first empty chunk CR", () {
+        test('after first empty chunk CR', () {
           sink.add([$0, $cr]);
           expect(results, isEmpty);
 
@@ -461,7 +458,7 @@ void main() {
           expect(results, isEmpty);
         });
 
-        test("after first empty chunk LF", () {
+        test('after first empty chunk LF', () {
           sink.add([$0, $cr, $lf]);
           expect(results, isEmpty);
 
@@ -472,7 +469,7 @@ void main() {
           expect(results, isEmpty);
         });
 
-        test("after second empty chunk CR", () {
+        test('after second empty chunk CR', () {
           sink.add([$0, $cr, $lf, $cr]);
           expect(results, isEmpty);
 
@@ -484,8 +481,8 @@ void main() {
         });
       });
 
-      group("addSlice()", () {
-        test("adds bytes from the specified slice", () {
+      group('addSlice()', () {
+        test('adds bytes from the specified slice', () {
           sink.addSlice([1, $3, $cr, $lf, 2, 3, 4, 5], 1, 7, false);
           expect(
               results,
@@ -499,23 +496,23 @@ void main() {
           expect(results, isEmpty);
         });
 
-        test("closes the sink if isLast is true", () {
+        test('closes the sink if isLast is true', () {
           sink.addSlice([1, $0, $cr, $lf, $cr, $lf, 7], 1, 6, true);
           expect(results, isEmpty);
         });
 
-        group("disallows", () {
-          test("start < 0", () {
+        group('disallows', () {
+          test('start < 0', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], -1, 4, false),
                 throwsRangeError);
           });
 
-          test("start > end", () {
+          test('start > end', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], 3, 2, false),
                 throwsRangeError);
           });
 
-          test("end > length", () {
+          test('end > length', () {
             expect(() => sink.addSlice([1, 2, 3, 4, 5], 1, 10, false),
                 throwsRangeError);
           });

--- a/test/http_date_test.dart
+++ b/test/http_date_test.dart
@@ -38,306 +38,306 @@ void main() {
     });
   });
 
-  group("parse", () {
-    group("RFC 1123", () {
-      test("parses the example date", () {
-        var date = parseHttpDate("Sun, 06 Nov 1994 08:49:37 GMT");
+  group('parse', () {
+    group('RFC 1123', () {
+      test('parses the example date', () {
+        var date = parseHttpDate('Sun, 06 Nov 1994 08:49:37 GMT');
         expect(date.day, equals(6));
         expect(date.month, equals(DateTime.november));
         expect(date.year, equals(1994));
         expect(date.hour, equals(8));
         expect(date.minute, equals(49));
         expect(date.second, equals(37));
-        expect(date.timeZoneName, equals("UTC"));
+        expect(date.timeZoneName, equals('UTC'));
       });
 
-      test("whitespace is required", () {
-        expect(() => parseHttpDate("Sun,06 Nov 1994 08:49:37 GMT"),
+      test('whitespace is required', () {
+        expect(() => parseHttpDate('Sun,06 Nov 1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06Nov 1994 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06Nov 1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov1994 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 199408:49:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov 199408:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:49:37GMT"),
-            throwsFormatException);
-      });
-
-      test("exactly one space is required", () {
-        expect(() => parseHttpDate("Sun,  06 Nov 1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06  Nov 1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov  1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov 1994  08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:49:37  GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:49:37GMT'),
             throwsFormatException);
       });
 
-      test("requires precise number lengths", () {
-        expect(() => parseHttpDate("Sun, 6 Nov 1994 08:49:37 GMT"),
+      test('exactly one space is required', () {
+        expect(() => parseHttpDate('Sun,  06 Nov 1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 94 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06  Nov 1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 8:49:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov  1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:9:37 GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov 1994  08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:49:7 GMT"),
-            throwsFormatException);
-      });
-
-      test("requires reasonable numbers", () {
-        expect(() => parseHttpDate("Sun, 00 Nov 1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 31 Nov 1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 32 Aug 1994 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 24:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:60:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun, 06 Nov 1994 08:49:60 GMT"),
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:49:37  GMT'),
             throwsFormatException);
       });
 
-      test("only allows short weekday names", () {
-        expect(() => parseHttpDate("Sunday, 6 Nov 1994 08:49:37 GMT"),
+      test('requires precise number lengths', () {
+        expect(() => parseHttpDate('Sun, 6 Nov 1994 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 94 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 8:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:9:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:49:7 GMT'),
             throwsFormatException);
       });
 
-      test("only allows short month names", () {
-        expect(() => parseHttpDate("Sun, 6 November 1994 08:49:37 GMT"),
+      test('requires reasonable numbers', () {
+        expect(() => parseHttpDate('Sun, 00 Nov 1994 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 31 Nov 1994 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 32 Aug 1994 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 24:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:60:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun, 06 Nov 1994 08:49:60 GMT'),
             throwsFormatException);
       });
 
-      test("only allows GMT", () {
-        expect(() => parseHttpDate("Sun, 6 Nov 1994 08:49:37 PST"),
+      test('only allows short weekday names', () {
+        expect(() => parseHttpDate('Sunday, 6 Nov 1994 08:49:37 GMT'),
             throwsFormatException);
       });
 
-      test("disallows trailing whitespace", () {
-        expect(() => parseHttpDate("Sun, 6 Nov 1994 08:49:37 GMT "),
+      test('only allows short month names', () {
+        expect(() => parseHttpDate('Sun, 6 November 1994 08:49:37 GMT'),
+            throwsFormatException);
+      });
+
+      test('only allows GMT', () {
+        expect(() => parseHttpDate('Sun, 6 Nov 1994 08:49:37 PST'),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => parseHttpDate('Sun, 6 Nov 1994 08:49:37 GMT '),
             throwsFormatException);
       });
     });
 
-    group("RFC 850", () {
-      test("parses the example date", () {
-        var date = parseHttpDate("Sunday, 06-Nov-94 08:49:37 GMT");
+    group('RFC 850', () {
+      test('parses the example date', () {
+        var date = parseHttpDate('Sunday, 06-Nov-94 08:49:37 GMT');
         expect(date.day, equals(6));
         expect(date.month, equals(DateTime.november));
         expect(date.year, equals(1994));
         expect(date.hour, equals(8));
         expect(date.minute, equals(49));
         expect(date.second, equals(37));
-        expect(date.timeZoneName, equals("UTC"));
+        expect(date.timeZoneName, equals('UTC'));
       });
 
-      test("whitespace is required", () {
-        expect(() => parseHttpDate("Sunday,06-Nov-94 08:49:37 GMT"),
+      test('whitespace is required', () {
+        expect(() => parseHttpDate('Sunday,06-Nov-94 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-9408:49:37 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-9408:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:49:37GMT"),
-            throwsFormatException);
-      });
-
-      test("exactly one space is required", () {
-        expect(() => parseHttpDate("Sunday,  06-Nov-94 08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sunday, 06-Nov-94  08:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:49:37  GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:49:37GMT'),
             throwsFormatException);
       });
 
-      test("requires precise number lengths", () {
-        expect(() => parseHttpDate("Sunday, 6-Nov-94 08:49:37 GMT"),
+      test('exactly one space is required', () {
+        expect(() => parseHttpDate('Sunday,  06-Nov-94 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-1994 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94  08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 8:49:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:9:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:49:7 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:49:37  GMT'),
             throwsFormatException);
       });
 
-      test("requires reasonable numbers", () {
-        expect(() => parseHttpDate("Sunday, 00-Nov-94 08:49:37 GMT"),
+      test('requires precise number lengths', () {
+        expect(() => parseHttpDate('Sunday, 6-Nov-94 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 31-Nov-94 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-1994 08:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 32-Aug-94 08:49:37 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 8:49:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 24:49:37 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:9:37 GMT'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:60:37 GMT"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sunday, 06-Nov-94 08:49:60 GMT"),
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:49:7 GMT'),
             throwsFormatException);
       });
 
-      test("only allows long weekday names", () {
-        expect(() => parseHttpDate("Sun, 6-Nov-94 08:49:37 GMT"),
+      test('requires reasonable numbers', () {
+        expect(() => parseHttpDate('Sunday, 00-Nov-94 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sunday, 31-Nov-94 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sunday, 32-Aug-94 08:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 24:49:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:60:37 GMT'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sunday, 06-Nov-94 08:49:60 GMT'),
             throwsFormatException);
       });
 
-      test("only allows short month names", () {
-        expect(() => parseHttpDate("Sunday, 6-November-94 08:49:37 GMT"),
+      test('only allows long weekday names', () {
+        expect(() => parseHttpDate('Sun, 6-Nov-94 08:49:37 GMT'),
             throwsFormatException);
       });
 
-      test("only allows GMT", () {
-        expect(() => parseHttpDate("Sunday, 6-Nov-94 08:49:37 PST"),
+      test('only allows short month names', () {
+        expect(() => parseHttpDate('Sunday, 6-November-94 08:49:37 GMT'),
             throwsFormatException);
       });
 
-      test("disallows trailing whitespace", () {
-        expect(() => parseHttpDate("Sunday, 6-Nov-94 08:49:37 GMT "),
+      test('only allows GMT', () {
+        expect(() => parseHttpDate('Sunday, 6-Nov-94 08:49:37 PST'),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => parseHttpDate('Sunday, 6-Nov-94 08:49:37 GMT '),
             throwsFormatException);
       });
     });
 
-    group("asctime()", () {
-      test("parses the example date", () {
-        var date = parseHttpDate("Sun Nov  6 08:49:37 1994");
+    group('asctime()', () {
+      test('parses the example date', () {
+        var date = parseHttpDate('Sun Nov  6 08:49:37 1994');
         expect(date.day, equals(6));
         expect(date.month, equals(DateTime.november));
         expect(date.year, equals(1994));
         expect(date.hour, equals(8));
         expect(date.minute, equals(49));
         expect(date.second, equals(37));
-        expect(date.timeZoneName, equals("UTC"));
+        expect(date.timeZoneName, equals('UTC'));
       });
 
-      test("parses a date with a two-digit day", () {
-        var date = parseHttpDate("Sun Nov 16 08:49:37 1994");
+      test('parses a date with a two-digit day', () {
+        var date = parseHttpDate('Sun Nov 16 08:49:37 1994');
         expect(date.day, equals(16));
         expect(date.month, equals(DateTime.november));
         expect(date.year, equals(1994));
         expect(date.hour, equals(8));
         expect(date.minute, equals(49));
         expect(date.second, equals(37));
-        expect(date.timeZoneName, equals("UTC"));
+        expect(date.timeZoneName, equals('UTC'));
       });
 
-      test("whitespace is required", () {
-        expect(() => parseHttpDate("SunNov  6 08:49:37 1994"),
+      test('whitespace is required', () {
+        expect(() => parseHttpDate('SunNov  6 08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov6 08:49:37 1994"),
+        expect(() => parseHttpDate('Sun Nov6 08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  608:49:37 1994"),
+        expect(() => parseHttpDate('Sun Nov  608:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  6 08:49:371994"),
-            throwsFormatException);
-      });
-
-      test("the right amount of whitespace is required", () {
-        expect(() => parseHttpDate("Sun  Nov  6 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov   6 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov 6 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov  6  08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov  6 08:49:37  1994"),
+        expect(() => parseHttpDate('Sun Nov  6 08:49:371994'),
             throwsFormatException);
       });
 
-      test("requires precise number lengths", () {
-        expect(() => parseHttpDate("Sun Nov 016 08:49:37 1994"),
+      test('the right amount of whitespace is required', () {
+        expect(() => parseHttpDate('Sun  Nov  6 08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  6 8:49:37 1994"),
+        expect(() => parseHttpDate('Sun Nov   6 08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  6 08:9:37 1994"),
+        expect(() => parseHttpDate('Sun Nov 6 08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  6 08:49:7 1994"),
+        expect(() => parseHttpDate('Sun Nov  6  08:49:37 1994'),
             throwsFormatException);
 
-        expect(() => parseHttpDate("Sun Nov  6 08:49:37 94"),
-            throwsFormatException);
-      });
-
-      test("requires reasonable numbers", () {
-        expect(() => parseHttpDate("Sun Nov 0 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov 31 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Aug 32 08:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov  6 24:49:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov  6 08:60:37 1994"),
-            throwsFormatException);
-
-        expect(() => parseHttpDate("Sun Nov  6 08:49:60 1994"),
+        expect(() => parseHttpDate('Sun Nov  6 08:49:37  1994'),
             throwsFormatException);
       });
 
-      test("only allows short weekday names", () {
-        expect(() => parseHttpDate("Sunday Nov 0 08:49:37 1994"),
+      test('requires precise number lengths', () {
+        expect(() => parseHttpDate('Sun Nov 016 08:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 8:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 08:9:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 08:49:7 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 08:49:37 94'),
             throwsFormatException);
       });
 
-      test("only allows short month names", () {
-        expect(() => parseHttpDate("Sun November 0 08:49:37 1994"),
+      test('requires reasonable numbers', () {
+        expect(() => parseHttpDate('Sun Nov 0 08:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov 31 08:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Aug 32 08:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 24:49:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 08:60:37 1994'),
+            throwsFormatException);
+
+        expect(() => parseHttpDate('Sun Nov  6 08:49:60 1994'),
             throwsFormatException);
       });
 
-      test("disallows trailing whitespace", () {
-        expect(() => parseHttpDate("Sun November 0 08:49:37 1994 "),
+      test('only allows short weekday names', () {
+        expect(() => parseHttpDate('Sunday Nov 0 08:49:37 1994'),
+            throwsFormatException);
+      });
+
+      test('only allows short month names', () {
+        expect(() => parseHttpDate('Sun November 0 08:49:37 1994'),
+            throwsFormatException);
+      });
+
+      test('disallows trailing whitespace', () {
+        expect(() => parseHttpDate('Sun November 0 08:49:37 1994 '),
             throwsFormatException);
       });
     });

--- a/test/media_type_test.dart
+++ b/test/media_type_test.dart
@@ -6,160 +6,160 @@ import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("parse", () {
-    test("parses a simple MIME type", () {
-      var type = MediaType.parse("text/plain");
-      expect(type.type, equals("text"));
-      expect(type.subtype, equals("plain"));
+  group('parse', () {
+    test('parses a simple MIME type', () {
+      var type = MediaType.parse('text/plain');
+      expect(type.type, equals('text'));
+      expect(type.subtype, equals('plain'));
     });
 
-    test("allows leading whitespace", () {
-      expect(MediaType.parse(" text/plain").mimeType, equals("text/plain"));
-      expect(MediaType.parse("\ttext/plain").mimeType, equals("text/plain"));
+    test('allows leading whitespace', () {
+      expect(MediaType.parse(' text/plain').mimeType, equals('text/plain'));
+      expect(MediaType.parse('\ttext/plain').mimeType, equals('text/plain'));
     });
 
-    test("allows trailing whitespace", () {
-      expect(MediaType.parse("text/plain ").mimeType, equals("text/plain"));
-      expect(MediaType.parse("text/plain\t").mimeType, equals("text/plain"));
+    test('allows trailing whitespace', () {
+      expect(MediaType.parse('text/plain ').mimeType, equals('text/plain'));
+      expect(MediaType.parse('text/plain\t').mimeType, equals('text/plain'));
     });
 
-    test("disallows separators in the MIME type", () {
-      expect(() => MediaType.parse("te(xt/plain"), throwsFormatException);
-      expect(() => MediaType.parse("text/pla=in"), throwsFormatException);
+    test('disallows separators in the MIME type', () {
+      expect(() => MediaType.parse('te(xt/plain'), throwsFormatException);
+      expect(() => MediaType.parse('text/pla=in'), throwsFormatException);
     });
 
-    test("disallows whitespace around the slash", () {
-      expect(() => MediaType.parse("text /plain"), throwsFormatException);
-      expect(() => MediaType.parse("text/ plain"), throwsFormatException);
+    test('disallows whitespace around the slash', () {
+      expect(() => MediaType.parse('text /plain'), throwsFormatException);
+      expect(() => MediaType.parse('text/ plain'), throwsFormatException);
     });
 
-    test("parses parameters", () {
-      var type = MediaType.parse("text/plain;foo=bar;baz=bang");
-      expect(type.mimeType, equals("text/plain"));
-      expect(type.parameters, equals({"foo": "bar", "baz": "bang"}));
+    test('parses parameters', () {
+      var type = MediaType.parse('text/plain;foo=bar;baz=bang');
+      expect(type.mimeType, equals('text/plain'));
+      expect(type.parameters, equals({'foo': 'bar', 'baz': 'bang'}));
     });
 
-    test("allows whitespace around the semicolon", () {
-      var type = MediaType.parse("text/plain ; foo=bar ; baz=bang");
-      expect(type.mimeType, equals("text/plain"));
-      expect(type.parameters, equals({"foo": "bar", "baz": "bang"}));
+    test('allows whitespace around the semicolon', () {
+      var type = MediaType.parse('text/plain ; foo=bar ; baz=bang');
+      expect(type.mimeType, equals('text/plain'));
+      expect(type.parameters, equals({'foo': 'bar', 'baz': 'bang'}));
     });
 
-    test("disallows whitespace around the equals", () {
+    test('disallows whitespace around the equals', () {
       expect(
-          () => MediaType.parse("text/plain; foo =bar"), throwsFormatException);
+          () => MediaType.parse('text/plain; foo =bar'), throwsFormatException);
       expect(
-          () => MediaType.parse("text/plain; foo= bar"), throwsFormatException);
+          () => MediaType.parse('text/plain; foo= bar'), throwsFormatException);
     });
 
-    test("disallows separators in the parameters", () {
+    test('disallows separators in the parameters', () {
       expect(
-          () => MediaType.parse("text/plain; fo:o=bar"), throwsFormatException);
+          () => MediaType.parse('text/plain; fo:o=bar'), throwsFormatException);
       expect(
-          () => MediaType.parse("text/plain; foo=b@ar"), throwsFormatException);
+          () => MediaType.parse('text/plain; foo=b@ar'), throwsFormatException);
     });
 
-    test("parses quoted parameters", () {
+    test('parses quoted parameters', () {
       var type =
           MediaType.parse('text/plain; foo="bar space"; baz="bang\\\\escape"');
-      expect(type.mimeType, equals("text/plain"));
+      expect(type.mimeType, equals('text/plain'));
       expect(
-          type.parameters, equals({"foo": "bar space", "baz": "bang\\escape"}));
+          type.parameters, equals({'foo': 'bar space', 'baz': 'bang\\escape'}));
     });
 
-    test("lower-cases type and subtype", () {
+    test('lower-cases type and subtype', () {
       var type = MediaType.parse('TeXt/pLaIn');
-      expect(type.type, equals("text"));
-      expect(type.subtype, equals("plain"));
-      expect(type.mimeType, equals("text/plain"));
+      expect(type.type, equals('text'));
+      expect(type.subtype, equals('plain'));
+      expect(type.mimeType, equals('text/plain'));
     });
 
-    test("records parameters as case-insensitive", () {
+    test('records parameters as case-insensitive', () {
       var type = MediaType.parse('test/plain;FoO=bar;bAz=bang');
-      expect(type.parameters, equals({"FoO": "bar", "bAz": "bang"}));
-      expect(type.parameters, containsPair("foo", "bar"));
-      expect(type.parameters, containsPair("baz", "bang"));
+      expect(type.parameters, equals({'FoO': 'bar', 'bAz': 'bang'}));
+      expect(type.parameters, containsPair('foo', 'bar'));
+      expect(type.parameters, containsPair('baz', 'bang'));
     });
   });
 
-  group("change", () {
+  group('change', () {
     MediaType type;
     setUp(() {
-      type = MediaType.parse("text/plain; foo=bar; baz=bang");
+      type = MediaType.parse('text/plain; foo=bar; baz=bang');
     });
 
-    test("uses the existing fields by default", () {
+    test('uses the existing fields by default', () {
       var newType = type.change();
-      expect(newType.type, equals("text"));
-      expect(newType.subtype, equals("plain"));
-      expect(newType.parameters, equals({"foo": "bar", "baz": "bang"}));
+      expect(newType.type, equals('text'));
+      expect(newType.subtype, equals('plain'));
+      expect(newType.parameters, equals({'foo': 'bar', 'baz': 'bang'}));
     });
 
-    test("[type] overrides the existing type", () {
-      expect(type.change(type: "new").type, equals("new"));
+    test('[type] overrides the existing type', () {
+      expect(type.change(type: 'new').type, equals('new'));
     });
 
-    test("[subtype] overrides the existing subtype", () {
-      expect(type.change(subtype: "new").subtype, equals("new"));
+    test('[subtype] overrides the existing subtype', () {
+      expect(type.change(subtype: 'new').subtype, equals('new'));
     });
 
-    test("[mimeType] overrides the existing type and subtype", () {
-      var newType = type.change(mimeType: "image/png");
-      expect(newType.type, equals("image"));
-      expect(newType.subtype, equals("png"));
+    test('[mimeType] overrides the existing type and subtype', () {
+      var newType = type.change(mimeType: 'image/png');
+      expect(newType.type, equals('image'));
+      expect(newType.subtype, equals('png'));
     });
 
-    test("[parameters] overrides and adds to existing parameters", () {
+    test('[parameters] overrides and adds to existing parameters', () {
       expect(
-          type.change(parameters: {"foo": "zap", "qux": "fblthp"}).parameters,
-          equals({"foo": "zap", "baz": "bang", "qux": "fblthp"}));
+          type.change(parameters: {'foo': 'zap', 'qux': 'fblthp'}).parameters,
+          equals({'foo': 'zap', 'baz': 'bang', 'qux': 'fblthp'}));
     });
 
-    test("[clearParameters] removes existing parameters", () {
+    test('[clearParameters] removes existing parameters', () {
       expect(type.change(clearParameters: true).parameters, isEmpty);
     });
 
-    test("[clearParameters] with [parameters] removes before adding", () {
+    test('[clearParameters] with [parameters] removes before adding', () {
       var newType =
-          type.change(parameters: {"foo": "zap"}, clearParameters: true);
-      expect(newType.parameters, equals({"foo": "zap"}));
+          type.change(parameters: {'foo': 'zap'}, clearParameters: true);
+      expect(newType.parameters, equals({'foo': 'zap'}));
     });
 
-    test("[type] with [mimeType] is illegal", () {
-      expect(() => type.change(type: "new", mimeType: "image/png"),
+    test('[type] with [mimeType] is illegal', () {
+      expect(() => type.change(type: 'new', mimeType: 'image/png'),
           throwsArgumentError);
     });
 
-    test("[subtype] with [mimeType] is illegal", () {
-      expect(() => type.change(subtype: "new", mimeType: "image/png"),
+    test('[subtype] with [mimeType] is illegal', () {
+      expect(() => type.change(subtype: 'new', mimeType: 'image/png'),
           throwsArgumentError);
     });
   });
 
-  group("toString", () {
-    test("serializes a simple MIME type", () {
-      expect(MediaType("text", "plain").toString(), equals("text/plain"));
+  group('toString', () {
+    test('serializes a simple MIME type', () {
+      expect(MediaType('text', 'plain').toString(), equals('text/plain'));
     });
 
-    test("serializes a token parameter as a token", () {
-      expect(MediaType("text", "plain", {"foo": "bar"}).toString(),
-          equals("text/plain; foo=bar"));
+    test('serializes a token parameter as a token', () {
+      expect(MediaType('text', 'plain', {'foo': 'bar'}).toString(),
+          equals('text/plain; foo=bar'));
     });
 
-    test("serializes a non-token parameter as a quoted string", () {
-      expect(MediaType("text", "plain", {"foo": "bar baz"}).toString(),
+    test('serializes a non-token parameter as a quoted string', () {
+      expect(MediaType('text', 'plain', {'foo': 'bar baz'}).toString(),
           equals('text/plain; foo="bar baz"'));
     });
 
-    test("escapes a quoted string as necessary", () {
-      expect(MediaType("text", "plain", {"foo": 'bar"\x7Fbaz'}).toString(),
+    test('escapes a quoted string as necessary', () {
+      expect(MediaType('text', 'plain', {'foo': 'bar"\x7Fbaz'}).toString(),
           equals('text/plain; foo="bar\\"\\\x7Fbaz"'));
     });
 
-    test("serializes multiple parameters", () {
+    test('serializes multiple parameters', () {
       expect(
-          MediaType("text", "plain", {"foo": "bar", "baz": "bang"}).toString(),
-          equals("text/plain; foo=bar; baz=bang"));
+          MediaType('text', 'plain', {'foo': 'bar', 'baz': 'bang'}).toString(),
+          equals('text/plain; foo=bar; baz=bang'));
     });
   });
 }


### PR DESCRIPTION
- prefer_single_quotes
- prefer_spread_collections

Bump minimum SDK to 2.3.0 to allow spreads in collection literals.