### PR TITLE
Block publish for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
-## 3.2.0-nullsafety
+## 4.0.0-nullsafety-dev
 
-Pre-release for the null safety migration of this package.
-
-Note that 3.2.0 may not be the final stable null safety release version, we
-reserve the right to release it as a 4.0.0 breaking change.
-
-This release will be pinned to only allow pre-release sdk versions starting from
-2.10.0-2.0.dev, which is the first version where this package will appear in the
-null safety allow list.
+* Migrate to null safety.
 
 ## 3.1.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,15 @@
 name: http_parser
-version: 3.2.0-nullsafety
+version: 3.2.0-nullsafety-dev
 description: >-
   A platform-independent package for parsing and serializing HTTP formats.
 homepage: https://github.com/dart-lang/http_parser
 
+# Unsafe to publish until null safety is stable or this package is in
+# the allow list
+publish_to: none
+
 environment:
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.11.0-0 <2.11.0'
 
 dependencies:
   charcode: ^1.2.0-nullsafety


### PR DESCRIPTION
- Append `-dev` to the version since this is unpublished.
- Add `publish_to: none` since this package is not in the allow list.
- Switch to a major version bump since this package is not pinned by
  flutter.
- Bump the min SDK to `2.11.0-0` since we won't ever publish a version
  compatible with `2.10` and we don't need to run against old dev SDKs
  on travis.