### PR TITLE
add default charset of application/json to utf-8

### DIFF
--- a/lib/src/media_type.dart
+++ b/lib/src/media_type.dart
@@ -72,6 +72,9 @@ class MediaType {
         }
 
         scanner.expectDone();
+        if(type=="application"&& subtype=="json" && parameters["charset"]==null){
+            parameters["charset"]="utf-8";
+        }
         return MediaType(type, subtype, parameters);
       });
 


### PR DESCRIPTION
add default charset of application/json to utf-8. as. https://github.com/dart-lang/http_parser/issues/39