### PR TITLE
Prepare for publishing 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-## 4.0.2-dev
-
 ## 4.0.1
 
 * Remove dependency on `package:charcode`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_parser
-version: 4.0.2-dev
+version: 4.0.1
 description: >-
   A platform-independent package for parsing and serializing HTTP formats.
 homepage: https://github.com/dart-lang/http_parser


### PR DESCRIPTION
It seems 4.0.1 was never published:
https://pub.dev/packages/http_parser/versions
﻿
