### PR TITLE
* `CaseInsensitiveMap`: added constructor `fromEntries`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 4.0.3-wip
 
+* `CaseInsensitiveMap`: added constructor `fromEntries`.
+
 * Require Dart 3.4
+
+* collection: ^1.19.0
 
 ## 4.0.2
 

--- a/lib/src/case_insensitive_map.dart
+++ b/lib/src/case_insensitive_map.dart
@@ -8,8 +8,18 @@ import 'package:collection/collection.dart';
 ///
 /// Much of HTTP is case-insensitive, so this is useful to have pre-defined.
 class CaseInsensitiveMap<V> extends CanonicalizedMap<String, String, V> {
-  CaseInsensitiveMap() : super((key) => key.toLowerCase());
+  /// Creates an empty case-insensitive map.
+  CaseInsensitiveMap() : super(_canonicalizer);
 
+  /// Creates a case-insensitive map that is initialized with the key/value
+  /// pairs of [other].
   CaseInsensitiveMap.from(Map<String, V> other)
-      : super.from(other, (key) => key.toLowerCase());
+      : super.from(other, _canonicalizer);
+
+  /// Creates a case-insensitive map that is initialized with the key/value
+  /// pairs of [entries].
+  CaseInsensitiveMap.fromEntries(Iterable<MapEntry<String, V>> entries)
+      : super.fromEntries(entries, _canonicalizer);
+
+  static String _canonicalizer(String key) => key.toLowerCase();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  collection: ^1.15.0
+  collection: ^1.19.0
   source_span: ^1.8.0
   string_scanner: ^1.1.0
   typed_data: ^1.3.0

--- a/test/case_insensitive_map_test.dart
+++ b/test/case_insensitive_map_test.dart
@@ -26,4 +26,10 @@ void main() {
     expect(map, containsPair('FoO', 'bAr'));
     expect(map, equals({'fOo': 'bAr'}));
   });
+
+  test('.fromEntries() converts an existing map', () {
+    final map = CaseInsensitiveMap.fromEntries({'fOo': 'bAr'}.entries);
+    expect(map, containsPair('FoO', 'bAr'));
+    expect(map, equals({'fOo': 'bAr'}));
+  });
 }


### PR DESCRIPTION

* `CaseInsensitiveMap`: added constructor `fromEntries`.

* collection: ^1.19.0

### Real-world case:

Avoid unnecessary overhead as seen here:

https://github.com/dart-lang/shelf/blob/master/pkgs/shelf/lib/src/headers.dart#L32

### Reason:

Improve Dart benchmark performance:

https://sharkbench.dev/web

---

- [ ✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

